### PR TITLE
Added instance_id to the player struct

### DIFF
--- a/src/tracking/cache.rs
+++ b/src/tracking/cache.rs
@@ -273,7 +273,6 @@ mod tests {
         let char3 = Player::new(
             789,
             3,
-
             "Char3",
             "Account2",
             false,

--- a/src/tracking/cache.rs
+++ b/src/tracking/cache.rs
@@ -221,6 +221,7 @@ mod tests {
 
         let player = Player::new(
             123,
+            456,
             "Char",
             "Acc",
             true,
@@ -249,6 +250,7 @@ mod tests {
 
         let char1 = Player::new(
             123,
+            1,
             "Char1",
             "Account1",
             false,
@@ -259,6 +261,7 @@ mod tests {
 
         let char2 = Player::new(
             456,
+            2,
             "Char2",
             "Account1",
             false,
@@ -269,6 +272,8 @@ mod tests {
 
         let char3 = Player::new(
             789,
+            3,
+
             "Char3",
             "Account2",
             false,

--- a/src/tracking/player.rs
+++ b/src/tracking/player.rs
@@ -12,7 +12,7 @@ pub struct Player {
     pub id: usize,
 
     // Player instance id on map
-    pub instance_id: usize,
+    pub instance_id: u16,
 
     /// Player character name.
     pub character: String,
@@ -40,7 +40,7 @@ impl Player {
     /// Creates a new player.
     pub fn new(
         id: usize,
-        instance_id: usize,
+        instance_id: u16,
         character: impl Into<String>,
         account: impl Into<String>,
         is_self: bool,
@@ -68,7 +68,7 @@ impl Player {
         let acc_name = dst.name?;
         Some(Self::new(
             src.id,
-            dst.id,
+            dst.id as u16,
             src.name?,
             strip_account_prefix(acc_name),
             dst.is_self != 0,

--- a/src/tracking/player.rs
+++ b/src/tracking/player.rs
@@ -38,6 +38,7 @@ pub struct Player {
 
 impl Player {
     /// Creates a new player.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: usize,
         instance_id: u16,

--- a/src/tracking/player.rs
+++ b/src/tracking/player.rs
@@ -11,6 +11,9 @@ pub struct Player {
     /// Player id given by the game.
     pub id: usize,
 
+    // Player instance id on map
+    pub instance_id: usize,
+
     /// Player character name.
     pub character: String,
 
@@ -37,6 +40,7 @@ impl Player {
     /// Creates a new player.
     pub fn new(
         id: usize,
+        instance_id: usize,
         character: impl Into<String>,
         account: impl Into<String>,
         is_self: bool,
@@ -46,6 +50,7 @@ impl Player {
     ) -> Self {
         Self {
             id,
+            instance_id,
             character: character.into(),
             account: account.into(),
             is_self,
@@ -59,9 +64,11 @@ impl Player {
     /// Creates a new player from tracking change agents.
     pub fn from_tracking_change(src: Agent, dst: Agent) -> Option<Self> {
         debug_assert!(src.elite == 0 && src.prof != 0);
+
         let acc_name = dst.name?;
         Some(Self::new(
             src.id,
+            dst.id,
             src.name?,
             strip_account_prefix(acc_name),
             dst.is_self != 0,


### PR DESCRIPTION
from https://www.deltaconnected.com/arcdps/api/README.txt
```
    combat: void fn(cbtevent* ev, ag* src, ag* dst, const char* skillname, uint64_t id, uint64_t revision)
            called asynchronously.
            ev parameter is cbtevent as in evtc documentation.
            ev may be null. if so, if src->elite == 1, then src->id is the id of the new targeted agent.
                                    else, if src->prof, src->id was added
                                                              src->name = char name
                                                              dst->name = acc names
                                                              src->id = id
                                                              dst->id = instance id on map
                                                         -----^
                                                              dst->prof = prof
                                                              dst->elite = elite spec
                                                              dst->self = is self
                                                              src->team = team id
                                                              dst->team = subgroup
                                          else, src->id was removed
```